### PR TITLE
Do not use the deprecated Buffer() constructor

### DIFF
--- a/test.js
+++ b/test.js
@@ -6,6 +6,8 @@ var callbackStream = require('callback-stream')
 var test = require('tape')
 var Throughv = require('./')
 
+var bufferFrom = Buffer.from && Buffer.from !== Uint8Array.from
+
 function itWorksInObjectMode (t, getInstance) {
   t.plan(6)
 
@@ -33,7 +35,7 @@ function itWorksWithBuffers (t, getInstance) {
 
   var list = []
   for (var i = 0; i < 2 * 16 * 1024; i++) {
-    list.push(new Buffer(1024))
+    list.push(bufferFrom ? Buffer.alloc(1024) : new Buffer(1024))
   }
   var transformed = 0
   var throughv = getInstance(function (chunk, enc, cb) {


### PR DESCRIPTION
Refs: https://github.com/nodejs/citgm/issues/605
Refs: https://nodejs.org/api/deprecations.html#deprecations_dep0005_buffer_constructor